### PR TITLE
Adds forward, back and play buttons to the year slider

### DIFF
--- a/css/ryht-charter-campuses.css
+++ b/css/ryht-charter-campuses.css
@@ -71,9 +71,13 @@ span#slider_back {
 	float: left;
 }
 
-span#slider_play {
+span#slider_play, span#slider_stop {
 	margin: 0 auto;
 	width: 100%;
+}
+
+span#slider_stop {
+	display: none;
 }
 
 span#slider_forward {

--- a/css/ryht-charter-campuses.css
+++ b/css/ryht-charter-campuses.css
@@ -59,6 +59,27 @@ input#slider {
 	height: 16px;
 }
 
+div#slidercontrols {
+	text-align: center;
+}
+
+div#slidercontrols span {
+	cursor: pointer;
+}
+
+span#slider_back {
+	float: left;
+}
+
+span#slider_play {
+	margin: 0 auto;
+	width: 100%;
+}
+
+span#slider_forward {
+	float: right;
+}
+
 .colors {
   background: linear-gradient(to right, #2dc4b2, #3bb3c3, #669ec4, #8b88b6, #a2719b, #aa5e79);
   margin-bottom: 5px;

--- a/index.html
+++ b/index.html
@@ -56,6 +56,7 @@
 					setTimeout(runWhenLoadComplete, 100);
 				}
 				else {
+					moveYearSlider('slider', 'active-year', 0); // calling this with a 0 increment will make sure that the filter, caption and slider position all match.  Without doing this, the browser seems to keep the slider position between refreshes, but reset the filter and caption so they get out of sync.
 					populateZoomControl("school-districts-control", "texas-school-districts", "NAME", "Texas School Districts");
 					map.moveLayer('texas-school-districts-lines', 'country-label-sm');
 					map.moveLayer('texas-school-districts-poly', 'texas-school-districts-lines');
@@ -267,7 +268,7 @@
 
 		<!--create time slider-->
 		  <div class='session' id='sliderbar'>
-		  <h2>Year: <label id='active-year'>1997</label></h2>
+		  <h2>Year: <label id='active-year'></label></h2>
 		  <input id='slider' class='row' type='range' min='1997' max='2018' step='1' value='1997' />
 		  </div>
 		  <div id='slidercontrols'>

--- a/index.html
+++ b/index.html
@@ -18,6 +18,8 @@
 	</style>
 
 		<script>
+		// global variable for whether the animation should be playing or not
+		var animationRunning = false;
 
 		//Adding showHide functionality from legislative map to this map
 		function showHideLayer(layerName, markerName, showOnly=false, hideOnly=false) {
@@ -195,6 +197,29 @@
 				slider.value = desiredYear;
 				updateYearSlider(numberID, desiredYear);
 			}
+
+			function animateYearSlider(sliderID, numberID, delay) {
+				if (animationRunning) {
+					moveYearSlider(sliderID, numberID, 1, loop=true);
+					setTimeout(
+						function() {animateYearSlider(sliderID, numberID, delay)},
+						delay
+					);
+				}
+			}
+
+			function startYearSlider(sliderID, numberID, delay, playID, stopID) {
+				animationRunning = true;
+				document.getElementById(playID).style.display = 'none';
+				document.getElementById(stopID).style.display = 'inline';
+				animateYearSlider(sliderID, numberID, delay);
+			}
+
+			function stopYearSlider(playID, stopID) {
+				animationRunning = false;
+				document.getElementById(playID).style.display = 'inline';
+				document.getElementById(stopID).style.display = 'none';
+			}
 		</script>
 
 </head>
@@ -273,7 +298,8 @@
 		  </div>
 		  <div id='slidercontrols'>
 		  	<span id='slider_back' onclick="moveYearSlider('slider', 'active-year', -1);" title='Go back one year'>&lt;</span>
-		  	<span id='slider_play' onclick="moveYearSlider('slider', 'active-year', 1, true);" title='Animate timeline'>play</span>
+		  	<span id='slider_play' onclick="startYearSlider('slider', 'active-year', 1000, 'slider_play', 'slider_stop');" title='Animate timeline'>play</span>
+		  	<span id='slider_stop' onclick="stopYearSlider('slider_play', 'slider_stop');" title='Stop animation'>stop</span>
 		  	<span id='slider_forward' onclick="moveYearSlider('slider', 'active-year', 1);" title='Go forward one year'>&gt;</span>
 		  </div>
 

--- a/index.html
+++ b/index.html
@@ -20,7 +20,6 @@
 		<script>
 
 		//Adding showHide functionality from legislative map to this map
-
 		function showHideLayer(layerName, markerName, showOnly=false, hideOnly=false) {
 			var visibility = map.getLayoutProperty(layerName, 'visibility');
 			if ((visibility === 'visible' || hideOnly) && !showOnly) {
@@ -36,6 +35,13 @@
 					document.getElementById(markerName).classList.remove('inactive');
 				}
 			}
+		}
+
+		// Update the year slider and corresponding map filter
+		function updateYearSlider(numberID, year) {
+		  map.setFilter('campuses', ['==', ['number', ['get', 'year']], parseInt(year, 10)]);
+		  // update text in the UI
+		  document.getElementById(numberID).innerText = year;
 		}
 
 
@@ -165,6 +171,29 @@
 					}
 				}
 			}
+
+			// the following functions are to automate control over the time slider
+			function moveYearSlider(sliderID, numberID, increment, loop=false) {
+				slider = document.getElementById(sliderID);
+				minYear = parseInt(slider.min, 10);
+				currentYear = parseInt(slider.value, 10);
+				maxYear = parseInt(slider.max, 10);
+
+				desiredYear = currentYear + increment;
+
+				if (loop) { // if we're looping then wrap any overflow around
+					if (desiredYear > maxYear) {desiredYear = minYear;}
+					else if (desiredYear < minYear) {desiredYear = maxYear;}
+				} else { // if not looping then keep changes within the min/max bounds
+					if ((desiredYear > maxYear) || (desiredYear < minYear)) {
+						desiredYear = currentYear;
+						console.log('Hacked too much time');
+					}
+				}
+
+				slider.value = desiredYear;
+				updateYearSlider(numberID, desiredYear);
+			}
 		</script>
 
 </head>
@@ -241,6 +270,11 @@
 		  <h2>Year: <label id='active-year'>1997</label></h2>
 		  <input id='slider' class='row' type='range' min='1997' max='2018' step='1' value='1997' />
 		  </div>
+		  <div id='slidercontrols'>
+		  	<span id='slider_back' onclick="moveYearSlider('slider', 'active-year', -1);" title='Go back one year'>&lt;</span>
+		  	<span id='slider_play' onclick="moveYearSlider('slider', 'active-year', 1, true);" title='Animate timeline'>play</span>
+		  	<span id='slider_forward' onclick="moveYearSlider('slider', 'active-year', 1);" title='Go forward one year'>&gt;</span>
+		  </div>
 
 	</div>
 
@@ -248,7 +282,7 @@
 
 
 <script>
-mapboxgl.accessToken = 'pk.eyJ1IjoiY29yZS1naXMiLCJhIjoiaUxqQS1zQSJ9.mDT5nb8l_dWIHzbnOTebcQ';
+		mapboxgl.accessToken = 'pk.eyJ1IjoiY29yZS1naXMiLCJhIjoiaUxqQS1zQSJ9.mDT5nb8l_dWIHzbnOTebcQ';
 
 		//set bounds to Texas
 		var bounds = [
@@ -417,13 +451,7 @@ mapboxgl.accessToken = 'pk.eyJ1IjoiY29yZS1naXMiLCJhIjoiaUxqQS1zQSJ9.mDT5nb8l_dWI
 
 		  //add interactivity to the time slider
 		  document.getElementById('slider').addEventListener('input', function(e) {
-			  var year = parseInt(e.target.value);
-			  // update the map
-			  map.setFilter('campuses', ['==', ['number', ['get', 'year']], year]);
-
-			  // update text in the UI
-			  document.getElementById('active-year').innerText = year;
-
+		  	updateYearSlider('active-year', e.target.value);
 			});
 
 			runWhenLoadComplete();

--- a/index.html
+++ b/index.html
@@ -208,14 +208,14 @@
 				}
 			}
 
-			function startYearSlider(sliderID, numberID, delay, playID, stopID) {
+			function startYearAnimation(sliderID, numberID, delay, playID, stopID) {
 				animationRunning = true;
 				document.getElementById(playID).style.display = 'none';
 				document.getElementById(stopID).style.display = 'inline';
 				animateYearSlider(sliderID, numberID, delay);
 			}
 
-			function stopYearSlider(playID, stopID) {
+			function stopYearAnimation(playID, stopID) {
 				animationRunning = false;
 				document.getElementById(playID).style.display = 'inline';
 				document.getElementById(stopID).style.display = 'none';
@@ -298,8 +298,8 @@
 		  </div>
 		  <div id='slidercontrols'>
 		  	<span id='slider_back' onclick="moveYearSlider('slider', 'active-year', -1);" title='Go back one year'>&lt;</span>
-		  	<span id='slider_play' onclick="startYearSlider('slider', 'active-year', 1000, 'slider_play', 'slider_stop');" title='Animate timeline'>play</span>
-		  	<span id='slider_stop' onclick="stopYearSlider('slider_play', 'slider_stop');" title='Stop animation'>stop</span>
+		  	<span id='slider_play' onclick="startYearAnimation('slider', 'active-year', 1000, 'slider_play', 'slider_stop');" title='Animate timeline'>play</span>
+		  	<span id='slider_stop' onclick="stopYearAnimation('slider_play', 'slider_stop');" title='Stop animation'>stop</span>
 		  	<span id='slider_forward' onclick="moveYearSlider('slider', 'active-year', 1);" title='Go forward one year'>&gt;</span>
 		  </div>
 


### PR DESCRIPTION
1. Adds the buttons as described.
2. Fixes a bug whereby if I moved the slider to any year but the first available and then reloaded the page, Firefox would keep the slider visually where it was, but reset the displayed year to 1997.

I expect you will want to style or replace the actual interface elements I've added, because they're pretty bare-bones:
![Screen Shot 2019-11-06 at 14 48 31](https://user-images.githubusercontent.com/1379812/68344921-044d4c80-00a5-11ea-8c54-2a891c27fb26.png)

Your call as to whether it's better to merge this and then do that, or add to this PR with the aesthetic improvements.