### PR TITLE
Clarification on chart title

### DIFF
--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -440,7 +440,7 @@ function drawChart() {
 			.attr("id", "chart-title")
 			.attr("x", (width/2)).attr("y", (-margin.top/4))
 			.attr("text-anchor", "middle")
-			.text(chartData.districtName);
+			.text((chartData.districtName === "Statewide" ? "All charter schools in Texas" : "Charter schools located within " + chartData.districtName));
 		g.append("text")
 			.attr("id", "left-axis-label")
 			.attr("fill", chartData.leftColor)


### PR DESCRIPTION
This is tiny, it just updates the chart title to show either "All charter schools in Texas" or "Charter schools located within Districtname".  Technically it's only half of what Max asked for, but making the Y axis names longer complicates the layout, so I think it's worth asking him if this is enough clarification.