### PR TITLE
Autocompletion UI for the districts list

### DIFF
--- a/css/ryht-charter-campuses.css
+++ b/css/ryht-charter-campuses.css
@@ -534,3 +534,25 @@ p.moreinfo  {
     display: none;
 }
 
+
+.autocomplete-items {
+  border: 1px solid #363635;
+  border-bottom: none;
+  border-top: none;
+  z-index: 99;
+}
+.autocomplete-items div {
+  padding: 2px;
+  cursor: pointer;
+  background-color: #fff;
+  border-bottom: 1px solid #363635;
+}
+.autocomplete-items div:hover {
+  background-color: #2DC4B2;
+  color: #ffffff;
+}
+.autocomplete-active {
+  /*when navigating through the items using the arrow keys:*/
+  background-color: #ee5e2a !important;
+  color: #ffffff;
+}

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
 			</p>
 			-->
 			<p class="moreinfo">
-				Use the drop-down menu below to zoom to a School District of your choice. Choose the top entry to return to the full extent of the state.
+				Use the drop-down menu below or type a School District name to zoom to a district of your choice. Choose the top entry to return to the full extent of the state.
 				<br /><br />
 
 				<!--Drop down controls-->

--- a/index.html
+++ b/index.html
@@ -29,6 +29,12 @@
 				Use the drop-down menu below or type a School District name to zoom to a district of your choice. Choose the top entry to return to the full extent of the state.
 				<br /><br />
 
+				<!-- Text box with autocomplete -->
+				<span class='autocomplete-container'>
+					<input id='districtAutocomplete' type='text' name='districtText' placeholder='' />
+				</span>
+				<br /><br />
+
 				<!--Drop down controls-->
 
 				<select id="school-districts-control" onchange="zoomToPolygon('texas-school-districts', this.value);"></select>

--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -108,6 +108,7 @@ var districts = {
 districts['Texas'] = districts['Statewide']
 districts['All'] = districts['Statewide']
 districts['zoom out'] = districts['Statewide']
+districts[''] = districts['Statewide']
 
 // global variable for whether the animation should be playing or not
 var animationRunning = false;
@@ -216,6 +217,8 @@ function populateZoomControl(selectID, sourceID, fieldName, layerName) {
 // IMPORTANT: these paint properties define the appearance of the mask layer that deemphasises districts outside the one we've zoomed to.  They will overrule anything that's set when that mask layer was loaded.
 	map.setPaintProperty(sourceID + '-poly', 'fill-color', 'rgba(200, 200, 200, 0.5)');
 	map.setPaintProperty(sourceID + '-lines', 'line-color', 'rgba(50, 50, 50, .7)');
+	// start the autocompletion event loop
+	autocomplete(document.getElementById('districtAutocomplete'), districts, sourceID);
 }
 
 function getPolygons(sourceID, nameField) {
@@ -695,4 +698,109 @@ function fillpopup(data){
 	html += "</span>";
 	return html;
 	//this will return the string to the calling function
+}
+
+
+
+
+// text box autocompletion functions adapted from https://www.w3schools.com/howto/howto_js_autocomplete.asp
+function autocomplete(inp, obj, sourceID) {
+	arr = Object.keys(obj);
+	/*the autocomplete function takes two arguments,
+	the text field element and an array of possible autocompleted values:*/
+	var currentFocus;
+	/*execute a function when someone writes in the text field:*/
+	inp.addEventListener("input", function(e) {
+		var a, b, i, val = this.value;
+		/*close any already open lists of autocompleted values*/
+		closeAllLists();
+		if (!val) { return false;}
+		currentFocus = -1;
+		/*create a DIV element that will contain the items (values):*/
+		a = document.createElement("div");
+		a.setAttribute("id", this.id + "autocomplete-list");
+		a.setAttribute("class", "autocomplete-items");
+		/*append the DIV element as a child of the autocomplete container:*/
+		this.parentNode.appendChild(a);
+		/*for each item in the array...*/
+		for (i = 0; i < arr.length; i++) {
+			/*check if the item starts with the same letters as the text field value:*/
+			if (arr[i].substr(0, val.length).toUpperCase() == val.toUpperCase()) {
+				/*create a DIV element for each matching element:*/
+				b = document.createElement("div");
+				/*make the matching letters bold:*/
+				b.innerHTML = "<strong>" + arr[i].substr(0, val.length) + "</strong>";
+				b.innerHTML += arr[i].substr(val.length);
+				/*insert a input field that will hold the current array item's value:*/
+				b.innerHTML += "<input type='hidden' value='" + arr[i] + "'>";
+				/*execute a function when someone clicks on the item value (DIV element):*/
+					b.addEventListener("click", function(e) {
+					/*insert the value for the autocomplete text field:*/
+					inp.value = this.getElementsByTagName("input")[0].value;
+					// zoom to it
+					zoomToPolygon(sourceID, obj[inp.value]);
+					/*close the list of autocompleted values,
+					(or any other open lists of autocompleted values:*/
+					closeAllLists();
+				});
+				a.appendChild(b);
+			}
+		}
+	});
+	/*execute a function presses a key on the keyboard:*/
+	inp.addEventListener("keydown", function(e) {
+		var x = document.getElementById(this.id + "autocomplete-list");
+		if (x) x = x.getElementsByTagName("div");
+		if (e.keyCode == 40) {
+			/*If the arrow DOWN key is pressed,
+			increase the currentFocus variable:*/
+			currentFocus++;
+			/*and and make the current item more visible:*/
+			addActive(x);
+		} else if (e.keyCode == 38) { //up
+			/*If the arrow UP key is pressed,
+			decrease the currentFocus variable:*/
+			currentFocus--;
+			/*and and make the current item more visible:*/
+			addActive(x);
+		} else if (e.keyCode == 13) {
+			/*If the ENTER key is pressed, see if this district is in the list */
+			if (arr.indexOf(this.value) > -1) {
+				// and if so, then zoom to it
+				zoomToPolygon(sourceID, obj[this.value]);
+				// and close open suggestions
+				closeAllLists();
+			}
+		}
+	});
+	function addActive(x) {
+		/*a function to classify an item as "active":*/
+		if (!x) return false;
+		/*start by removing the "active" class on all items:*/
+		removeActive(x);
+		if (currentFocus >= x.length) currentFocus = 0;
+		if (currentFocus < 0) currentFocus = (x.length - 1);
+		/*add class "autocomplete-active":*/
+		x[currentFocus].classList.add("autocomplete-active");
+	}
+	function removeActive(x) {
+		/*a function to remove the "active" class from all autocomplete items:*/
+		for (var i = 0; i < x.length; i++) {
+			x[i].classList.remove("autocomplete-active");
+		}
+	}
+	function closeAllLists(elmnt) {
+		/*close all autocomplete lists in the document,
+		except the one passed as an argument:*/
+		var x = document.getElementsByClassName("autocomplete-items");
+		for (var i = 0; i < x.length; i++) {
+			if (elmnt != x[i] && elmnt != inp) {
+			x[i].parentNode.removeChild(x[i]);
+		}
+	}
+}
+/*execute a function when someone clicks in the document:*/
+	document.addEventListener("click", function (e) {
+		closeAllLists(e.target);
+	});
 }

--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -98,11 +98,16 @@ var chartData = {
 };
 
 // data structure to hold a list of districts and their bounding boxes.  Format for each entry is:
-// 'Name': 'W,N,E,S'  // WNES being how Mapbox gives us bboxes
+// 'Name': 'W,N,E,S,Name'  // WNES being how Mapbox gives us bboxes, and the name repetition being what we feed to the chart updater
 // and individual districts' values will be auto-populated from data
 var districts = {
-	'Statewide': '-108,25,-88,37'
+	'Statewide': '-108,25,-88,37,Statewide'
 }
+
+// now let's give "Statewide" some synonyms for usability
+districts['Texas'] = districts['Statewide']
+districts['All'] = districts['Statewide']
+districts['zoom out'] = districts['Statewide']
 
 // global variable for whether the animation should be playing or not
 var animationRunning = false;
@@ -201,11 +206,11 @@ function populateZoomControl(selectID, sourceID, fieldName, layerName) {
 	var select = document.getElementById(selectID);
 	select.options[0] = new Option(layerName, districts.Statewide + ",Statewide");
 	for (i in polygons) {
-		bbox = polygons[i].bbox.toString();
+		payload = polygons[i].bbox.toString() + ',' + polygons[i].name;
 		select.options[select.options.length] = new Option(
-			polygons[i].name, bbox + ',' + polygons[i].name
+			polygons[i].name, payload
 		);
-		districts[polygons[i].name] = bbox;
+		districts[polygons[i].name] = payload;
 	}
 	map.setLayoutProperty(sourceID + '-poly', 'visibility', 'none');
 // IMPORTANT: these paint properties define the appearance of the mask layer that deemphasises districts outside the one we've zoomed to.  They will overrule anything that's set when that mask layer was loaded.

--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -132,7 +132,6 @@ function allocateScreenSpace() {
 	var mapDiv = document.getElementById("map");
 	mapDiv.style.height = viewportHeight - svgHeight - controlsHeight;
 	mapDiv.style.width = viewportWidth - sidenavWidth;
-	console.log(viewportWidth, sidenavWidth, activeControlPadding, svgWidth);
 	return [svgWidth, svgHeight];
 }
 

--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -97,6 +97,13 @@ var chartData = {
 	}
 };
 
+// data structure to hold a list of districts and their bounding boxes.  Format for each entry is:
+// 'Name': 'W,N,E,S'  // WNES being how Mapbox gives us bboxes
+// and individual districts' values will be auto-populated from data
+var districts = {
+	'Statewide': '-108,25,-88,37'
+}
+
 // global variable for whether the animation should be playing or not
 var animationRunning = false;
 
@@ -192,12 +199,13 @@ function runWhenLoadComplete() {
 function populateZoomControl(selectID, sourceID, fieldName, layerName) {
 	polygons = getPolygons(sourceID, fieldName);
 	var select = document.getElementById(selectID);
-	select.options[0] = new Option(layerName, "-108,25,-88,37,Statewide");
+	select.options[0] = new Option(layerName, districts.Statewide + ",Statewide");
 	for (i in polygons) {
+		bbox = polygons[i].bbox.toString();
 		select.options[select.options.length] = new Option(
-			polygons[i].name,
-			polygons[i].bbox.toString() + ',' + polygons[i].name
+			polygons[i].name, bbox + ',' + polygons[i].name
 		);
+		districts[polygons[i].name] = bbox;
 	}
 	map.setLayoutProperty(sourceID + '-poly', 'visibility', 'none');
 // IMPORTANT: these paint properties define the appearance of the mask layer that deemphasises districts outside the one we've zoomed to.  They will overrule anything that's set when that mask layer was loaded.

--- a/scripts/onload.js
+++ b/scripts/onload.js
@@ -189,4 +189,3 @@ d3.csv(districtsFile).then(function(data) {
 	drawChart();
 	window.addEventListener("resize", redrawChart);
 });
-

--- a/scripts/onload.js
+++ b/scripts/onload.js
@@ -181,7 +181,6 @@ d3.csv(districtsFile).then(function(data) {
 				datum = districtHistory['Statewide'][j];
 				field = fieldMappings[chartFields[i]].csvVarName;
 				base = fieldMappings[chartFields[i]].ratioBase;
-				console.log(datum, field, base);
 				datum[field].pct = datum[field].abs / datum[fieldMappings[base].csvVarName].abs;
 			}
 		}


### PR DESCRIPTION
I will admit to being rather pleased with myself, even though this is mostly code copy-pasted from an online resource.  The text box does the following:

- If you start typing, it gives you autocomplete suggestions.
- Those suggestions can be navigated by mouse or cursor keys.
- Clicking on one, or pressing return after typing a complete district name, zooms to the district.
- Pressing return on an empty text box, or picking any of "Texas", "Statewide", "All", or "zoom out" zooms back to the whole state

It's slightly simplified relative to the example code I was using, and generalised just enough that if we later decide to add the same functionality to the list of charter school companies, or to limit the districts list to only those with data, either will be easy.