### PR TITLE
Small screen layout tweaks

### DIFF
--- a/css/ryht-charter-campuses.css
+++ b/css/ryht-charter-campuses.css
@@ -534,6 +534,16 @@ p.moreinfo  {
     display: none;
 }
 
+p.moreinfo {
+	margin-bottom: 2ex;
+	padding-right: 2ex;
+}
+
+input.autocompleteTextbox, select.dropdown {
+	display: block;
+	margin-top: 1ex;
+	margin-bottom: 1ex;
+}
 
 .autocomplete-items {
   border: 1px solid #363635;

--- a/css/ryht-charter-campuses.css
+++ b/css/ryht-charter-campuses.css
@@ -456,7 +456,8 @@ p.navtitle {
 }
 
 p.moreinfo  {
-  padding: 8px 8px 8px 32px;
+  padding: 8px 16px 8px 32px;
+	margin-bottom: 2ex;
   background: #ffff;
   color:#4a4a4a;
   font-family: "Montserrat", Arial, Helvetica, sans-serif;
@@ -534,15 +535,24 @@ p.moreinfo  {
     display: none;
 }
 
-p.moreinfo {
-	margin-bottom: 2ex;
-	padding-right: 2ex;
-}
-
 input.autocompleteTextbox, select.dropdown {
 	display: block;
 	margin-top: 1ex;
 	margin-bottom: 1ex;
+}
+
+div.sidenav.tallpage p.moreinfo {
+	margin-top: 2em;
+	font-size: 14px;
+}
+
+div.sidenav.shortpage p.moreinfo {
+	margin-top: 0.5ex;
+	margin-bottom: 1ex;
+	padding-right: 8px;
+	font-size: 10px;
+	line-height: 11px;
+	overflow-y: auto;
 }
 
 .autocomplete-items {

--- a/index.html
+++ b/index.html
@@ -21,36 +21,30 @@
 		<div id="mySidenav" class="sidenav">
 			<p class="moreinfo">
 				Use the drop-down menu below or type a School District name to zoom to a district of your choice. Choose the top entry to return to the full extent of the state.
-				<br /><br />
 
 				<!-- Text box with autocomplete -->
 				<span class='autocomplete-container'>
 					<input class='autocompleteTextbox' id='districtAutocomplete' type='text' name='districtText' placeholder='' />
 				</span>
-				<br /><br />
 
 				<!--Drop down controls-->
 
 				<select class='dropdown' id="school-districts-control" onchange="zoomToPolygon('campuses', this.value, false);"></select>
-				<br /><br />
 
 <!--END 'ZOOM TO DISTRICT'-->
 
 <!--BEGIN 'ZOOM TO CHARTER'-->
 			<p class="moreinfo">
 				Use the drop-down menu below or type a charter company name to see just that company's campuses. Choose the top entry to show all Charter Campuses again.
-				<br /><br />
 
 				<!-- Text box with autocomplete -->
 				<span class='autocomplete-container'>
 					<input class='autocompleteTextbox' id='charterAutocomplete' type='text' name='charterText' placeholder='' />
 				</span>
-				<br /><br />
 
 				<!--Drop down controls-->
 
 				<select class='dropdown' id="charter-filter-control" onchange="zoomToPolygon('campuses', this.value, 'ref_distnm');"></select>
-				<br /><br />
 
 		</div> <!-- id="mySidenav" -->
 <!--END 'ZOOM TO CHARTER'-->

--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -135,12 +135,8 @@ function allocateScreenSpace() {
 	var viewportWidth = Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
 	var viewportHeight = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
 	// adjust text size + spacing for sidenav
-	console.log(document.getElementById('console'));
-	console.log(document.getElementById('console').offsetHeight);
-	console.log(document.getElementById('console').style.height);
 	var sidenav = document.getElementById('mySidenav');
 	sidenav.style.height = viewportHeight - document.getElementById('console').offsetHeight;
-	console.log(viewportWidth, viewportHeight);
 	if (viewportHeight > 840) {
 		sidenav.classList.add('tallpage');
 		sidenav.classList.remove('shortpage');

--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -134,7 +134,25 @@ var popupState = {};
 function allocateScreenSpace() {
 	var viewportWidth = Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
 	var viewportHeight = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
-	var sidenavWidth = Math.max(document.getElementById('mySidenav').clientWidth, document.getElementById('mySidenav').innerWidth || 0);
+	// adjust text size + spacing for sidenav
+	console.log(document.getElementById('console'));
+	console.log(document.getElementById('console').offsetHeight);
+	console.log(document.getElementById('console').style.height);
+	var sidenav = document.getElementById('mySidenav');
+	sidenav.style.height = viewportHeight - document.getElementById('console').offsetHeight;
+	console.log(viewportWidth, viewportHeight);
+	if (viewportHeight > 840) {
+		sidenav.classList.add('tallpage');
+		sidenav.classList.remove('shortpage');
+	}
+	else if (viewportHeight < 700) {
+		sidenav.classList.remove('tallpage');
+		sidenav.classList.add('shortpage');
+	} else {
+		sidenav.classList.remove('tallpage');
+		sidenav.classList.remove('shortpage');
+	}
+	var sidenavWidth = Math.max(sidenav.clientWidth, sidenav.innerWidth || 0);
 	var activeControlDiv = document.getElementById(
 		(chartData.visible ? 'chart-controls' : 'chart-open-link')
 	);


### PR DESCRIPTION
I've ended up changing a few things together, so:

- When the viewport height is > 840px, you'll see slightly larger text around the dropdowns, simply because when we have a load of whitespace we may as well give bigger text.
- When it is between 700 & 840 px, you'll see the same text size as before, but with slightly tighter vertical spacing.
- When it is < 700px you'll see smaller text and tighter vertical spacing.
- When it gets small enough that a scrollbar is _still_ needed to show the whole controls even with that smaller text, then one will appear (this is a less precise threshold than the others because it depends on browser rendering details).

The scrollbar is _ugly_, so I've tried to make it only appear as a last resort.  Please test this and let me know if you're able to see it before you get to really awkwardly small window sizes.  If that does happen, I think it will be worth me applying similar dynamic formatting to the console that has the colour legend in it, to free up some more vertical space.