### PR TITLE
Text changes double counting fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
 <!--BEGIN 'ZOOM TO DISTRICT'-->
 		<div id="mySidenav" class="sidenav">
 			<p class="moreinfo">
-				Use the drop-down menu below or type a School District name to zoom to a district of your choice. Choose the top entry to return to the full extent of the state.
+				Use the drop-down menu below or type a school district name to zoom to a district of your choice. Choose the top entry to return to the full extent of the state.
 
 				<!-- Text box with autocomplete -->
 				<span class='autocomplete-container'>
@@ -35,7 +35,7 @@
 
 <!--BEGIN 'ZOOM TO CHARTER'-->
 			<p class="moreinfo">
-				Use the drop-down menu below or type a charter company name to see just that company's campuses. Choose the top entry to show all Charter Campuses again.
+				Use the drop-down menu below or type a charter holder name to see just that holder's campuses. Choose the top entry to show all charter campuses again.
 
 				<!-- Text box with autocomplete -->
 				<span class='autocomplete-container'>

--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -240,8 +240,8 @@ function runWhenLoadComplete() {
 			[-93.25, 36.75] // northeast coords, exaggerated somewhat towards the NE to make the state appear more visually centred
 		]);
 		moveYearSlider('slider', 'active-year', 0); // calling this with a 0 increment will make sure that the filter, caption and slider position all match.  Without doing this, the browser seems to keep the slider position between refreshes, but reset the filter and caption so they get out of sync.
-		populateZoomControl("school-districts-control", "texas-school-districts", "NAME", "Texas School Districts", districts, districts.Statewide);
-		populateZoomControl("charter-filter-control", "texas-charter-companies", "ref_distnm", "All charter schools", charters, charters.All);
+		populateZoomControl("school-districts-control", "texas-school-districts", "NAME", "Texas school districts", districts, districts.Statewide);
+		populateZoomControl("charter-filter-control", "texas-charter-companies", "ref_distnm", "All charter holders", charters, charters.All);
 		map.moveLayer('texas-school-districts-lines', 'country-label-sm');
 		map.moveLayer('texas-school-districts-poly', 'texas-school-districts-lines');
 		for (i=0; i < loadedLineLayers.length; i++) {

--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -260,7 +260,13 @@ function populateZoomControl(selectID, sourceID, fieldName, layerName, globalDat
 	var select = document.getElementById(selectID);
 	select.options[0] = new Option(layerName, defaultVal + ",Statewide");
 	for (i in polygons) {
-		payload = polygons[i].bbox.toString() + ',' + polygons[i].name;
+		// for the charter holders controls, make all zoom targets the whole state
+		if (selectID === 'charter-filter-control') {
+			payload = '-108,25,-88,37';
+		} else { // for any other controls, use bounding boxes from the polygons
+			payload = polygons[i].bbox.toString();
+		}
+		payload += ',' + polygons[i].name;
 		select.options[select.options.length] = new Option(
 			polygons[i].name, payload
 		);

--- a/scripts/onload.js
+++ b/scripts/onload.js
@@ -174,7 +174,6 @@ d3.csv(districtsFile).then(function(data) {
 			d.sumData = false;
 		})
 		data = data.concat(charterData);
-		console.log(data);
 		populateChartControls();
 		var districtHistory = {'Statewide': {}};
 		data.forEach(function(d) {
@@ -219,8 +218,6 @@ d3.csv(districtsFile).then(function(data) {
 			}
 		}
 		chartData.dataset = districtHistory;
-		console.log(districtHistory);
-		console.log(districtHistory.Statewide);
 		drawChart();
 		window.addEventListener("resize", redrawChart);
 	});


### PR DESCRIPTION
I think this now covers everything, **but** it's going to be particularly important to check with RYHT because I have a slightly different diagnosis of the "double counting" bug from what Max saw.  What I think I did wrong before was to accidentally construct the statewide totals from all districts + all charter holders, which will work out to precisely double counting when both datasets are complete, or approximately double counting if either is incomplete (which would be how we had an odd number of campuses for 2017 even though it's still in the double-counted range).  The reason I am doubting myself is that this applies to _all_ variables, whereas Max only saw it for # of campuses.  But I'm reasonably confident because the data before this fix had a very suspicious number of even numbers in it, which I should have picked up on a month ago - it's the classic warning sign of a double counting type bug.  So I'll drop Max an email about that and it might be worth waiting for his reply before merging this.

There's one other detail I'll check in with him about, which is that I ended up making the charter holders control always zoom to statewide, but it might be better to make it just not zoom at all.  If that's his preference, it's an easy change for me to make.